### PR TITLE
Trigger actions on push as well

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,10 @@
 name: PR validation
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   check:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 name: PR validation
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   check:


### PR DESCRIPTION
This is necessary so the action is run on merges into the main branch
too. That wouldn't necessarily be required since we enforce the checks
to succeed before merging anyway, but we want to run our actions on
main too in order to populate the caches that can then be reused on PR
branches. Otherwise, each PR branch would have a first run that doesn't
have any caches available.

https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache